### PR TITLE
Update Fisker Ocean generations: Add Wikipedia reference and correct production end year

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Fisker Ocean
 
+This repository contains signal set configurations for the Fisker Ocean, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Fisker Ocean.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,8 @@
+references:
+  - "https://en.wikipedia.org/wiki/Fisker_Ocean"
+
 generations:
   - name: "First Generation"
     start_year: 2022
-    end_year: null
+    end_year: 2024
     description: "The Fisker Ocean is an all-electric SUV that represents the rebirth of the Fisker brand under founder Henrik Fisker after the original company's bankruptcy in 2013. Built on a dedicated EV platform developed in collaboration with Magna Steyr (who also manufactures the vehicle in Austria), it features distinctive styling that balances aerodynamic efficiency with traditional SUV proportions. The exterior design incorporates several innovative elements including a solar roof that can add up to 1,500 miles of range annually in optimal conditions, a 'California Mode' that opens all windows and the roof with a single touch, and a unique rear window that can be lowered to accommodate long items. Available in various trim levels including Sport, Ultra, and Extreme, the powertrain options range from a single-motor front-wheel drive setup producing 275 HP in the base model to a dual-motor all-wheel drive system delivering up to 564 HP in the Extreme variant. Battery capacity also varies by model, with the larger 106 kWh pack in higher trims providing an EPA-estimated range of up to 360 miles. The interior features a minimalist design focused on sustainability, using recycled materials including plastics recovered from the ocean. Technology highlights include a massive 17.1-inch central touchscreen that can rotate between portrait and landscape orientations, a digital instrument display, and comprehensive driver assistance systems. The Ocean represents Fisker's vision for sustainable mobility, combining performance, technology, and environmental consciousness in a package designed to compete with established premium electric SUVs."


### PR DESCRIPTION
- Added references array with Wikipedia article link
- Corrected end_year from null to 2024 (production ceased in June 2024)
- Updated README.md with standard template

Evidence from Wikipedia infobox: "production = 2022–2024"
Narrative confirmation: "In June 2024, the company announced it had filed for bankruptcy and was indefinitely suspending production of the Ocean."

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
